### PR TITLE
chore: move home component to app/(home) folder and separate page.tsx

### DIFF
--- a/apps/minsu_dev/src/app/(home)/error.tsx
+++ b/apps/minsu_dev/src/app/(home)/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import styles from './home.module.css';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.errorContainer}>
+      <h2 className={styles.errorTitle}>
+        포스트 리스트를 가져오는 중 에러가 발생했습니다.
+      </h2>
+      <button className={styles.errorButton} onClick={() => reset()}>
+        다시 시도하세요.
+      </button>
+    </div>
+  );
+}

--- a/apps/minsu_dev/src/app/(home)/home.module.css
+++ b/apps/minsu_dev/src/app/(home)/home.module.css
@@ -1,0 +1,19 @@
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+}
+
+.errorTitle {
+  color: #fff;
+  font-size: 2rem;
+}
+
+.errorButton {
+  margin-top: 20px;
+  padding: 20px;
+  border-radius: 10px;
+  font-size: 1rem;
+}

--- a/apps/minsu_dev/src/app/(home)/page.tsx
+++ b/apps/minsu_dev/src/app/(home)/page.tsx
@@ -1,15 +1,19 @@
 import { createClient } from '@/utils/supabase/server';
 import { cookies } from 'next/headers';
 import { PostList } from '@/foo/home/list';
-import styles from '../foo/layout.module.css';
+import styles from '@/foo/layout.module.css';
 
 export default async function Home() {
   const supabase = createClient(cookies());
-  const { data } = await supabase.from('Post').select('*');
+  const { data } = await supabase
+    .from('Post')
+    .select('*')
+    .order('created_at', { ascending: false });
+
   return (
     <section className={styles.homeContainer}>
       <PostList
-        initalPosts={data?.map(post => ({
+        initialPosts={data?.map(post => ({
           ...post,
           tags: JSON.parse(post.tags) as string[],
         }))}

--- a/apps/minsu_dev/src/foo/home/list/list.tsx
+++ b/apps/minsu_dev/src/foo/home/list/list.tsx
@@ -7,14 +7,14 @@ import { PostCard } from '@/components/common/post/card';
 import { useInfinitePosts } from './list.hooks';
 import { PostListProps } from './list.types';
 
-const PostList: FC<PostListProps> = ({ tag, initalPosts }) => {
+const PostList: FC<PostListProps> = ({ tag, initialPosts }) => {
   const { ref, inView } = useInView();
   const {
     data: postPages,
     fetchNextPage,
     hasNextPage,
     // @ts-ignore useInfiniteQuery query type added later
-  } = useInfinitePosts(tag, initalPosts);
+  } = useInfinitePosts(tag, initialPosts);
 
   useEffect(() => {
     if (inView && hasNextPage) fetchNextPage();

--- a/apps/minsu_dev/src/foo/home/list/list.types.ts
+++ b/apps/minsu_dev/src/foo/home/list/list.types.ts
@@ -2,7 +2,7 @@ import { Post } from '@/types';
 
 export type PostListProps = {
   tag?: string;
-  initalPosts?: Post[];
+  initialPosts?: Post[];
 };
 
 export interface FetchPostsParams {


### PR DESCRIPTION
# Overview

- home 컴포넌트를 src/app/page.tsx 에서 app/(home) 폴더로 이동하였습니다.
- 기존의 home 컴포넌트 로직을 app/(home)/page.tsx 파일로 분리하였습니다.
- app/(home) 폴더에 error.tsx 파일을 새롭게 추가하여 오류 처리 로직을 분리하였습니다.
- 포스트 글 내림차순으로 정렬해 가져오는 형식으로 추가했습니다.